### PR TITLE
Hide lock arrows when 2nd magnet is not showing

### DIFF
--- a/src/components/magnet/magnet-canvas.tsx
+++ b/src/components/magnet/magnet-canvas.tsx
@@ -231,7 +231,7 @@ export class MagnetCanvas extends BaseComponent<IProps, IState> {
           ? <SlideArrowWithApp arrowComplete={this.handleSlideArrowComplete}/>
           : null
         }
-        {simulation.showMagneticForces
+        {magnet2 && simulation.showMagneticForces
           ? <LockArrows/>
           : null
         }


### PR DESCRIPTION
The force arrow lock icon needs to be hidden if we remove the 2nd magnet