### PR TITLE
Fix position of add magnet text

### DIFF
--- a/src/components/top-bar.sass
+++ b/src/components/top-bar.sass
@@ -128,7 +128,7 @@
         left: 25px
       &.right
         top: 27px
-        left: 858px
+        left: 33px
 
   .icon
     position: absolute


### PR DESCRIPTION
Position of "add magnet" text was incorrect causing it not to be shown.