### PR TITLE
Add extra pointerup handling to fix case where magnets overlap

### DIFF
--- a/src/components/magnet/magnet.tsx
+++ b/src/components/magnet/magnet.tsx
@@ -5,6 +5,10 @@ import { IMagnetProps } from "./magnet-canvas";
 
 const kVoltageImageYOffset = 84;
 const kSideImageXOffset = 66;
+const kMaxDragX = 950;
+const kMinDragX = 10;
+const kMaxDragY = 650;
+const kMinDragY = 100;
 
 interface IProps {
   app: Application;
@@ -47,10 +51,21 @@ export default class Magnet extends React.Component<IProps, IState> {
 
   public componentDidMount() {
     this.props.app.ticker.add(this.tick);
+    window.addEventListener("pointerup", this.handlePointerUp);
   }
 
   public componentWillUnmount() {
     this.props.app.ticker.remove(this.tick);
+    window.removeEventListener("pointerup", this.handlePointerUp);
+  }
+
+  public handlePointerUp = (e: any) => {
+    if (e.offsetX > kMinDragX && e.offsetX < kMaxDragX && e.offsetY > kMinDragY && e.offsetY < kMaxDragY) {
+      this.setState({
+        isDragging: false,
+        dragData: null
+      });
+    }
   }
 
   public calculateRotation = (delta: any) => {


### PR DESCRIPTION
In previous versions, if a user dragged a magnet and released the magnet while it overlapped a second magnet, the pointer up handling didn't always correctly end the drag (the pointer up would be handled by the magnet that wasn't being dragged).  This would put the user into situation where the mouse buttons were up, but the magnet was still being dragged.  This PR adds an extra event handler that ends magnet dragging when a pointer up is detected in the main canvas area (note that the top and bottom spaces and left and right edges are ignored so that the magnet drag cannot end when the magnet is offscreen, behind UI elements, etc. - in other words, we're also trying to prevent drags from ending when the magnet is in a location where the user will not be able to drag it again).