### PR TITLE
Add url param to show/hide field representation controls

### DIFF
--- a/src/components/bottom-bar.tsx
+++ b/src/components/bottom-bar.tsx
@@ -5,10 +5,10 @@ import { BaseComponent, IBaseProps } from "./base";
 import "./bottom-bar.sass";
 
 import { MagFieldPanelComponent } from "./mag-field-control-panel";
-import { CompassComponent } from "./compass";
 import { StrengthPanelComponent } from "./strength-panel";
 import { MagForcesPanelComponent } from "./mag-forces-panel";
 import { PolarityPanelComponent } from "./polarity-panel";
+import { urlParams } from "../utilities/url-params";
 
 interface IProps extends IBaseProps {}
 interface IState {}
@@ -18,9 +18,11 @@ interface IState {}
 export class BottomBarComponent extends BaseComponent<IProps, IState> {
 
   public render() {
+    const {fieldRepresentations} = urlParams;
     const {simulation} = this.stores;
     const primaryMag = simulation.getMagnetAtIndex(0);
     const secondaryMag = simulation.getMagnetAtIndex(1);
+    const showMagFieldPanel: boolean = fieldRepresentations ? fieldRepresentations.toLowerCase() === "true" : false;
     const showMagForces: boolean = primaryMag != null && secondaryMag != null;
     if (!primaryMag) {
       return (
@@ -40,7 +42,7 @@ export class BottomBarComponent extends BaseComponent<IProps, IState> {
             </div>
           : null
           }
-          <MagFieldPanelComponent/>
+          {showMagFieldPanel && <MagFieldPanelComponent/>}
           {showMagForces ?
             <MagForcesPanelComponent/>
             : null}

--- a/src/components/magnet/magnet-canvas.tsx
+++ b/src/components/magnet/magnet-canvas.tsx
@@ -222,7 +222,7 @@ export class MagnetCanvas extends BaseComponent<IProps, IState> {
           <GradientField magnets={magnets} magnetModels={magnetModels} width={width} height={height} cellSize={10} />
         }
         {
-          simulation.showPointers && !rotating1 && !rotating2 &&
+          simulation.showPointers && !rotating1 && !rotating2 && (magnet1 || magnet2) &&
           <VectorField magnets={magnets} magnetModels={magnetModels} width={width} height={height} cellSize={30} />
         }
         {

--- a/src/models/simulation.test.ts
+++ b/src/models/simulation.test.ts
@@ -11,7 +11,7 @@ describe("simulation model", () => {
     expect(simulation.magnets).toEqual([]);
     expect(simulation.showFieldLines).toBe(false);
     expect(simulation.showCloud).toBe(false);
-    expect(simulation.showPointers).toBe(false);
+    expect(simulation.showPointers).toBe(true);
     expect(simulation.showMagneticForces).toBe(false);
   });
 

--- a/src/models/simulation.ts
+++ b/src/models/simulation.ts
@@ -8,7 +8,7 @@ export const SimulationModel = types
   .model("Simulation", {
     showFieldLines: false,
     showCloud: false,
-    showPointers: false,
+    showPointers: true,
     showMagneticForces: false,
     magnets: types.array(SimulationMagnet),
     slideArrowStarted: false,

--- a/src/utilities/url-params.ts
+++ b/src/utilities/url-params.ts
@@ -3,12 +3,15 @@ import { AppMode } from "../models/stores";
 
 export interface QueryParams {
   appMode?: AppMode;
+  // turn field representation control on/off
+  fieldRepresentations?: string;
 }
 
 const params = parse(location.search);
 
 export const DefaultUrlParams: QueryParams = {
   appMode: "dev",
+  fieldRepresentations: "false",
 };
 
 export const urlParams: QueryParams = params;


### PR DESCRIPTION
This PR adds a URL parameter to show/hide the magnetic field representation panel.  As per the story spec the following is implemented:
- by default the field representations panel is hidden
- the panel is shown if the following URL parameter is present ?fieldRepresentations=true
- magnetic field pointers are now turned on by default

Default version (no panel)
https://magnets.concord.org/magnets/branch/url-params-field-representation/

URL param version (panel is shown)
https://magnets.concord.org/magnets/branch/url-params-field-representation/?fieldRepresentations=true