### PR TITLE
Add url param to show/hide second magnet option

### DIFF
--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -4,6 +4,7 @@ import { BaseComponent, IBaseProps } from "./base";
 
 import "./top-bar.sass";
 import { MagnetType, SimulationMagnet } from "../models/simulation-magnet";
+import { urlParams } from "../utilities/url-params";
 
 interface IProps extends IBaseProps {}
 interface IState {}
@@ -13,6 +14,8 @@ interface IState {}
 export class TopBarComponent extends BaseComponent<IProps, IState> {
 
   public render() {
+    const {magnets} = urlParams;
+    const showRight = !magnets || (parseInt(magnets, 10) !== 1);
     const {ui, simulation} = this.stores;
     const curtainClass = ui.showTopBarCurtain ? "curtain unrolled" : "curtain";
     const leftMagText = "Select a magnet";
@@ -38,16 +41,20 @@ export class TopBarComponent extends BaseComponent<IProps, IState> {
           <div className="label add left">Select a magnet</div>
           {this.renderBarButton(leftMagType, "left", primaryDisabledClass, this.handleClickLeftMagnetBarButton)}
           {this.renderCoilButton(leftMagType, "left", primaryDisabledClass, this.handleClickLeftMagnetCoilButton)}
-          <svg className="divider">
-            <use xlinkHref="#icon-divider"/>
-          </svg>
-          <div className={"label add right " + rightDisabledClass}>Add a 2nd magnet</div>
-          {this.renderBarButton(rightMagType, "right", rightDisabledClass, this.handleClickRightMagnetBarButton)}
-          {this.renderCoilButton(rightMagType, "right", rightDisabledClass, this.handleClickRightMagnetCoilButton)}
-          {this.renderRemoveButton(removeDisabledClass)}
+          {showRight &&
+            <div>
+              <svg className="divider">
+                <use xlinkHref="#icon-divider"/>
+              </svg>
+              <div className={"label add right " + rightDisabledClass}>Add a 2nd magnet</div>
+              {this.renderBarButton(rightMagType, "right", rightDisabledClass, this.handleClickRightMagnetBarButton)}
+              {this.renderCoilButton(rightMagType, "right", rightDisabledClass, this.handleClickRightMagnetCoilButton)}
+              {this.renderRemoveButton(removeDisabledClass)}
+            </div>
+          }
         </div>
         {this.renderMagnetButton(leftMagText, leftMagType, "left")}
-        {this.renderMagnetButton(rightMagText, rightMagType, "right")}
+        {showRight && this.renderMagnetButton(rightMagText, rightMagType, "right")}
       </div>
     );
   }

--- a/src/utilities/url-params.ts
+++ b/src/utilities/url-params.ts
@@ -5,6 +5,8 @@ export interface QueryParams {
   appMode?: AppMode;
   // turn field representation control on/off
   fieldRepresentations?: string;
+  // the number of magnets, ?magnets=1 to only allow 1 magnet
+  magnets?: string;
 }
 
 const params = parse(location.search);
@@ -12,6 +14,7 @@ const params = parse(location.search);
 export const DefaultUrlParams: QueryParams = {
   appMode: "dev",
   fieldRepresentations: "false",
+  magnets: "2",
 };
 
 export const urlParams: QueryParams = params;


### PR DESCRIPTION
This PR adds a URL parameter to enable/disable the second magnet (the right magnet).  As per the story spec the following is implemented:

- by default both magnets are enabled
- the second magnet and associated UI is disabled and hidden if the following URL parameter is present ?magnets=1

Default version (both magnets)
https://magnets.concord.org/magnets/branch/url-params-one-magnet/

URL param version (single magnet)
https://magnets.concord.org/magnets/branch/url-params-one-magnet/?magnets=1