### PR TITLE
Change z-order of lock arrow

### DIFF
--- a/src/components/magnet/magnet-canvas.tsx
+++ b/src/components/magnet/magnet-canvas.tsx
@@ -216,6 +216,10 @@ export class MagnetCanvas extends BaseComponent<IProps, IState> {
           simulation.showFieldLines && !rotating1 && !rotating2 &&
           <FieldLines magnets={magnets} magnetModels={magnetModels} width={width} height={height} />
         }
+        {magnet2 && simulation.showMagneticForces
+          ? <LockArrows/>
+          : null
+        }
         {
           magnet1 &&
           <MagWithApp
@@ -260,10 +264,6 @@ export class MagnetCanvas extends BaseComponent<IProps, IState> {
         }
         {simulation.slideArrowStarted && !simulation.slideArrowComplete
           ? <SlideArrowWithApp arrowComplete={this.handleSlideArrowComplete}/>
-          : null
-        }
-        {magnet2 && simulation.showMagneticForces
-          ? <LockArrows/>
           : null
         }
       </Stage>


### PR DESCRIPTION
Change z-order of magnetic forces lock arrows so they appear behind the magnets.