### PR TITLE
Add new URL parameters necessary for CZI interactive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "magnets",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/bottom-bar.tsx
+++ b/src/components/bottom-bar.tsx
@@ -18,12 +18,12 @@ interface IState {}
 export class BottomBarComponent extends BaseComponent<IProps, IState> {
 
   public render() {
-    const {fieldRepresentations, strength} = urlParams;
+    const {fieldRepresentations, strength, forceArrowsPanel} = urlParams;
     const {simulation} = this.stores;
     const primaryMag = simulation.getMagnetAtIndex(0);
     const secondaryMag = simulation.getMagnetAtIndex(1);
     const showMagFieldPanel: boolean = fieldRepresentations ? fieldRepresentations.toLowerCase() === "true" : false;
-    const showMagForces: boolean = primaryMag != null && secondaryMag != null;
+    const showMagForces: boolean = forceArrowsPanel === "true" && primaryMag != null && secondaryMag != null;
     const showStrengthPanel: boolean = strength ? strength.toLowerCase() !== "false" : true;
     if (!primaryMag) {
       return (

--- a/src/utilities/url-params.ts
+++ b/src/utilities/url-params.ts
@@ -14,6 +14,14 @@ export interface QueryParams {
   // toggle polarity control panel mode (flip/polarity)
   // ?current=true changes flip panel to polarity panel
   current?: string;
+  // toggle the top bar UI letting user pick magnet type
+  // ?topBar=false hides the UI and loads the simulation with defaults magnets in place
+  topBar?: string;
+  // turn magnetic force arrows panel on/off, ?forceArrows=true to enable
+  forceArrowsPanel: string;
+  // default value of magnetic force arrows rendering and X axis locking
+  // ?foreArrows=true shows force arrows and locks X axis on simulation load
+  forceArrows: string;
 }
 
 const params = parse(location.search);
@@ -24,7 +32,10 @@ export const DefaultUrlParams: QueryParams = {
   magnets: "2",
   battery: "false",
   strength: "true",
-  current: "true"
+  current: "true",
+  topBar: "true",
+  forceArrowsPanel: "true",
+  forceArrows: "false"
 };
 
-export const urlParams: QueryParams = params;
+export const urlParams: QueryParams = {...DefaultUrlParams, ...params };


### PR DESCRIPTION
The goal is to create a sim as described here:
https://www.pivotaltracker.com/story/show/176005261

This PR adds a few URL params that will let us do that. The final config:
http://magnets.concord.org/branch/czi-params/index.html?topBar=false&forceArrows=true&forceArrowsPanel=false&strength=false

Note that there's one risky change here - the default URL params were NOT used before. I mean the hash variable was unused. So, probably components assumed these values in their implementation. I've fixed that so the default values are actually used. It doesn't seem to change the default state of the sim, but just a warning in case I'm missing something.



