### PR TITLE
Add new URL parameters necessary for CZI interactive

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -5,7 +5,9 @@ import { urlParams } from "../utilities/url-params";
 import { TopBarComponent } from "./top-bar";
 import { MainContentComponent } from "./main-content";
 import { BottomBarComponent } from "./bottom-bar";
-import { SimulationMagnet } from "../models/simulation-magnet";
+import {
+  kBarStrengthMedium, kBarStrengthStrong, kBarStrengthWeak, SimulationMagnet
+} from "../models/simulation-magnet";
 
 import "./app.sass";
 
@@ -50,16 +52,17 @@ export class AppComponent extends BaseComponent<IProps, IState> {
   }
 
   public setupDefaultSimulation() {
-    const {topBar, magnets, forceArrows} = urlParams;
+    const {topBar, magnets, initialStrength} = urlParams;
     const {simulation} = this.stores;
     if (topBar === "false") {
+      const barStrength = initialStrength === "strong" ? kBarStrengthStrong :
+        (initialStrength === "medium" ? kBarStrengthMedium : kBarStrengthWeak);
       // Add default magnets, as user wouldn't be able to do it without top bar.
-      simulation.addMagnet(SimulationMagnet.create({active: true, type: "bar"}));
+      simulation.addMagnet(SimulationMagnet.create({active: true, type: "bar", barStrength}));
       if (magnets === "2") {
-        simulation.addMagnet(SimulationMagnet.create({active: true, type: "bar"}));
+        simulation.addMagnet(SimulationMagnet.create({active: true, type: "bar", barStrength}));
       }
     }
-    simulation.setShowMagneticForces(forceArrows === "true");
   }
 
   public render() {

--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -3,7 +3,13 @@ import * as React from "react";
 import { BaseComponent, IBaseProps } from "./base";
 
 import "./top-bar.sass";
-import { MagnetType, SimulationMagnet } from "../models/simulation-magnet";
+import {
+  kBarStrengthMedium,
+  kBarStrengthStrong,
+  kBarStrengthWeak, kCoilStrengthMedium, kCoilStrengthStrong, kCoilStrengthWeak,
+  MagnetType,
+  SimulationMagnet
+} from "../models/simulation-magnet";
 import { urlParams } from "../utilities/url-params";
 
 interface IProps extends IBaseProps {}
@@ -145,11 +151,19 @@ export class TopBarComponent extends BaseComponent<IProps, IState> {
 
   private addOrUpdateMagnet = (index: number, magType: any) => {
     const {simulation} = this.stores;
-    const {battery} = urlParams;
+    const {battery, initialStrength} = urlParams;
     const mag = simulation.getMagnetAtIndex(index);
     const showBattery = magType === "coil" ? (battery ? battery.toLowerCase() === "true" : false) : false;
     if (mag == null) {
-      simulation.addMagnet(SimulationMagnet.create({active: true, type: magType}));
+      if (magType === "bar") {
+        const barStrength = initialStrength === "strong" ? kBarStrengthStrong :
+          (initialStrength === "medium" ? kBarStrengthMedium : kBarStrengthWeak);
+        simulation.addMagnet(SimulationMagnet.create({active: true, type: magType, barStrength}));
+      } else {
+        const coilStrength = initialStrength === "strong" ? kCoilStrengthStrong :
+          (initialStrength === "medium" ? kCoilStrengthMedium : kCoilStrengthWeak);
+        simulation.addMagnet(SimulationMagnet.create({active: true, type: magType, coilStrength}));
+      }
     } else {
       simulation.setMagnetType(index, magType);
     }

--- a/src/models/simulation-magnet.ts
+++ b/src/models/simulation-magnet.ts
@@ -1,5 +1,6 @@
 import { types } from "mobx-state-tree";
 import uuid = require("uuid");
+import { urlParams } from "../utilities/url-params";
 
 export const MagnetTypeEnum = types.enumeration("type", ["bar", "coil"]);
 export type MagnetType = typeof MagnetTypeEnum.Type;
@@ -61,6 +62,9 @@ export const SimulationMagnet = types
       },
       get magnetImage(): string {
         if (self.type === "bar") {
+          if (urlParams.multipleBars === "false") {
+            return "assets/magnet-bar-1.png";
+          }
           switch (self.barStrength) {
             case kBarStrengthStrong:
               return "assets/magnet-bar-3.png";

--- a/src/models/simulation.ts
+++ b/src/models/simulation.ts
@@ -1,15 +1,17 @@
 import { types } from "mobx-state-tree";
 import { SimulationMagnetType, SimulationMagnet, MagnetType,
         CoilPolarityType, PolarityType } from "./simulation-magnet";
+import { urlParams } from "../utilities/url-params";
 
+const { forceArrows, fieldArrows } = urlParams;
 const kMaxMagnets = 2;
 
 export const SimulationModel = types
   .model("Simulation", {
     showFieldLines: false,
     showCloud: false,
-    showPointers: true,
-    showMagneticForces: false,
+    showPointers: fieldArrows === "true",
+    showMagneticForces: forceArrows === "true",
     magnets: types.array(SimulationMagnet),
     slideArrowStarted: false,
     slideArrowComplete: false,

--- a/src/utilities/url-params.ts
+++ b/src/utilities/url-params.ts
@@ -22,6 +22,15 @@ export interface QueryParams {
   // default value of magnetic force arrows rendering and X axis locking
   // ?foreArrows=true shows force arrows and locks X axis on simulation load
   forceArrows: string;
+  // default value of magnetic field arrows rendering
+  // ?fieldArrows=true shows field arrows
+  fieldArrows: string;
+  // initial strength of the magnet when it's added
+  // ?initialStrength=weak/medium/strong
+  initialStrength: "weak" | "medium" | "strong";
+  // toggle rendering of multiple bars for stronger magnets
+  // ?multipleBars=false renders only one bar for each magnet strength
+  multipleBars: string;
 }
 
 const params = parse(location.search);
@@ -35,7 +44,10 @@ export const DefaultUrlParams: QueryParams = {
   current: "true",
   topBar: "true",
   forceArrowsPanel: "true",
-  forceArrows: "false"
+  forceArrows: "false",
+  fieldArrows: "true",
+  initialStrength: "weak",
+  multipleBars: "true"
 };
 
 export const urlParams: QueryParams = {...DefaultUrlParams, ...params };


### PR DESCRIPTION
[#176005261]

More params for Dan's interactive. One to disable field arrows, and one to set initial strength (he wanted stronger magnets), plus another to disable rendering of multiple bars. Dan didn't ask about this one specifically, but I feel he will, as multiple bars without strength control can be confusing.